### PR TITLE
Fix links to documentation

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -87,10 +87,23 @@ parent = "Repositories"
 weight = 4
 
 [[languages.en.menu.main]]
-identifier = "documentation"
 name = "Documentation"
 url = "/documentation/"
 weight = 30
+
+[[languages.en.menu.main]]
+identifier = "documentation-core"
+name = "Core"
+url = "https://kokkos.github.io/kokkos-core-wiki/"
+parent = "Documentation"
+weight = 1
+
+[[languages.en.menu.main]]
+identifier = "documentation-kernels"
+name = "Kernels"
+url = "https://github.com/kokkos/kokkos-kernels/wiki"
+parent = "Documentation"
+weight = 2
 
 [[languages.en.menu.main]]
 identifier = "blog"


### PR DESCRIPTION
Merge before #11 

Snapshot dropdown menu:

![image](https://github.com/kokkos/kokkos.github.io/assets/62652182/17b321ca-4186-4e49-a488-d3075e130d45)

Core link is: https://kokkos.github.io/kokkos-core-wiki/

Kernels link is: https://github.com/kokkos/kokkos-kernels/wiki