### PR TITLE
Change Kokkos Core Documentation URL

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -93,7 +93,7 @@ weight = 30
 [[languages.en.menu.main]]
 identifier = "documentation-core"
 name = "Core"
-url = "https://kokkos.github.io/kokkos-core-wiki/"
+url = "https://kokkos.github.io/kokkos-core-documentation/"
 parent = "Documentation"
 weight = 1
 


### PR DESCRIPTION
Following meeting discussion, this PR proposes a change to the Kokkos Core Documentation URL (as accessed from main kokkos.org page).  Additional PR to better organize , update and streamline the website will follow. 