### PR TITLE
Do not convert the url/path to lowercase

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -1,4 +1,5 @@
 baseurl = "http://kokkos.org/"
+disablePathToLower = true
 title = "Kokkos"
 languagecode = "en-us"
 staticDir = [ "assets" ]


### PR DESCRIPTION
We refer to the https://kokkos.org/LICENSE everywhere in our headers but following that URL yield a 404 Page not found error...

https://github.com/kokkos/kokkos/blob/06e4c5bdc5502d5833728e2bee3d30d03eff1d97/core/src/Kokkos_Core.hpp#L12