### PR TITLE
Event: Kokkos training at Maison de la Simulation, Jun 2024

### DIFF
--- a/content/outreach/events-details/event-04.md
+++ b/content/outreach/events-details/event-04.md
@@ -1,0 +1,30 @@
+---
+authors: ["kokkos-team"]
+title: "Event: Kokkos Training in Paris, France June 2024"
+date: "2024-05-07"
+tags: ["Kokkos", "event"]
+---
+
+Start: Jun 17, 2024, 8:00 AM
+End: Jun 21, 2024, 6:00 PM
+
+We are pleased to announce that we are hosting the next **Kokkos Training** June 17-21, 20249 at the Maison de la Simulation in Paris, France. This event will include a live Kokkos Tutorial session, hands on work sessions and technical dissussions and meeting. Kokkos expert from CEA, Oak Ridge National Lab and Sandia National Labs will be available for discussions and to help attendee port codes and optimize performance of their applications.
+
+Schedule:
+ - Mon Jun. 17: Kokkos Tutorial lecture
+ - Tue, Wed 18-19: Practical work in lab
+ - Thu, Fri 20-21: Technical discussions session and project/application teams meetings
+
+Who should attend?  
+Anyone who has a C++ application, or would like to create C++ Kokkos capability that hooks onto an application, and would like to have a single source code run well on multiple platforms. We also encourage developers to bring applications that already use Kokkos since Kokkos experts will be available to help with more advanced use cases. Although we strongly suggest teams of two (or more) per application, please do not hesitate to apply if you are a single developer who wants attend this event.
+
+What happens at the event?
+We will have Kokkos experts to help you with your application. This event is a tutorial and a playground to experiment with integrating Kokkos with your application and to help optimize existing Kokkos applications.
+
+What happens after the event?   
+Attendance to this event will help us create a relationship with your team that we hope to continue as you return home to continue your work. The Kokkos is always available on its Slack channel: [kokkosteam.slack.com](kokkosteam.slack.com)
+
+How should I prepare?
+If you are new to Kokkos, we can help you prepare a kernel for the event. If you have an existing Kokkos application, we would like to understand your needs before the event. We hope that doing this prep work will maximize your time learning from Kokkos experts.
+
+[comment]: # (How do I apply?)

--- a/content/outreach/events.md
+++ b/content/outreach/events.md
@@ -7,6 +7,8 @@ tags: [""]
 
 # Current Events
 
+[Kokkos Training in Paris, France June 2024]({{<ref "/outreach/events-details/event-04" >}})
+
 # Past Events
 
 [Kokkos User Group Meeting 2023]({{< ref "/community/kug-2023" >}} "Kokkos User Group Meeting 2023")


### PR DESCRIPTION
Adding draft of event entry for the upcoming training at Maison de la Simulation in June. This will likely need to be refined but for now that is a good enough draft...