### PR TITLE
Set up Google Analytics

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -310,3 +310,12 @@ defaultContentLanguageInSubdir = false
   [[module.mounts]]
     source = "static/download"
     target = "static/downloads"
+
+[services]
+  [services.googleAnalytics]
+    id = 'G-TXYTG29JXM'
+
+[privacy]
+  [privacy.googleAnalytics]
+    disable = false
+    respectDoNotTrack = false


### PR DESCRIPTION
Try Hugo' support for Google Analytics since we cannot get traffic information on Github Pages at this time.