### PR TITLE
Revert "Merge pull request #143 from dalg24/add_google_analytics_to_header_file"

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,4 +1,0 @@
-<head>
-  {{ template "_internal/google_analytics.html" . }}
-</head>
-


### PR DESCRIPTION
The header is broken, it "swallows" the top of pages.  I suggest we revert.

This reverts commit 9a214a446d86998e84786623876ca4c3be9b67df, reversing changes made to 30712aa586ee599c738fc76390b82dbfde37b9ac.