### PR TITLE
Add working groups info

### DIFF
--- a/content/wgs.md
+++ b/content/wgs.md
@@ -1,0 +1,23 @@
+---
+title: "Kokkos Working Groups"
+date: "2025-03-12"
+---
+
+This page lists active Kokkos Working Groups (WGs).
+
+[Continuous Integration]( {{< ref "wgs/continuous-integration" >}} )
+--------------------------------------------------------------------
+The Kokkos CI Working Group focuses on maintaining and improving the continuous
+integration (CI) infrastructure for the Kokkos C++ performance portability
+library. This group collaborates to ensure robust testing, efficient build
+processes, and timely feedback for developers, contributing to the overall
+stability and reliability of the Kokkos ecosystem.
+
+[Build and Packaging]( {{< ref "wgs/build-and-packaging" >}} )
+--------------------------------------------------------------
+The Kokkos Build and Packaging Working Group is dedicated to streamlining the
+process of building and distributing the Kokkos performance portability
+library. This group focuses on developing and maintaining robust build systems,
+creating consistent and user-friendly packaging solutions, and ensuring
+compatibility across various platforms and environments. Their efforts aim to
+simplify the user experience and facilitate wider adoption of Kokkos.

--- a/content/wgs/build-and-packaging.md
+++ b/content/wgs/build-and-packaging.md
@@ -1,0 +1,37 @@
+---
+title: "Build and Packaging"
+date: "2025-03-12"
+---
+
+Overview
+--------
+This Working Group is dedicated to streamlining the process of building and
+distributing the Kokkos performance portability library. This group focuses on
+developing and maintaining robust build systems, creating consistent and
+user-friendly packaging solutions, and ensuring compatibility across various
+platforms and environments. Their efforts aim to simplify the user experience
+and facilitate wider adoption of Kokkos.
+
+[(Back to List of Kokkos Working Groups)]( {{< ref "wgs" >}})
+
+Members
+-------
+**Leads:**
+* Cédric Chevalier
+
+**Participants**
+* Luc Berger-Vergiat
+* Jakob Bludau
+* Damien Lebrun-Grandié
+* Nic Morales
+* Thomas Padioleau
+
+Connect
+-------
+* **Slack channel:** [kokkos-wg-build-and-packaging](https://kokkosteam.slack.com/archives/C08HHLY3490)
+  (Contact the leads to get invited)
+* **Mailing list:** <https://lists.hpsf.io/g/kokkos-wg-build-and-packaging>
+
+Meetings
+--------
+TBD

--- a/content/wgs/continuous-integration.md
+++ b/content/wgs/continuous-integration.md
@@ -1,0 +1,42 @@
+---
+title: "Continuous Integration"
+date: "2025-03-12"
+---
+
+Overview
+--------
+This Working Group focuses on maintaining and improving the continuous
+integration (CI) infrastructure for the Kokkos C++ performance portability
+library. This group collaborates to ensure robust testing, efficient build
+processes, and timely feedback for developers, contributing to the overall
+stability and reliability of the Kokkos ecosystem.
+
+[(Back to List of Kokkos Working Groups)]( {{< ref "wgs" >}})
+
+Members
+-------
+**Leads:**
+* Nathan Ellingwood
+* Damien Lebrun-Grandié
+
+**Participants:**
+* Daniel Arndt
+* Luc Berger-Vergiat
+* Jakob Bludau
+* Conrad Clevenger
+* Rahul Gayatri
+* Bruno Turcksin
+* Paul Zehner
+
+Connect
+-------
+* **Slack channel:** [kokkos-wg-continuous-integration](https://kokkosteam.slack.com/archives/C07JRFJ1XCN)
+  (Contact the leads to get invited)
+* **Mailing list:** <https://lists.hpsf.io/g/kokkos-wg-continuous-integration>
+
+Meetings
+--------
+* Schedule: one meeting every two weeks, usually on Mondays.
+* [Meeting link (Zoom)](https://zoom-lfx.platform.linuxfoundation.org/meeting/96720820014?password=fbe6b9eb-7833-4e88-94d2-23150acfcb0e)
+* Agenda (TBD)
+* Minutes previous meetings (TBD)


### PR DESCRIPTION
I created pages for the Continuous Integration and Build and Packaging WGs.
Their goal is to publicize these groups and their respective activities.

I drafted an initial mission statement but I expect the groups will refine and provide some extended description listing topics of interest and a roadmap.

I created mailing lists for the groups.  I will leave it up to you whether you want to use them for announcements, discussions, and/or distributing meeting agendas.