### PR TITLE
Removing the "Sandia" tag that was added to the Team page

### DIFF
--- a/content/community/team.md
+++ b/content/community/team.md
@@ -2,7 +2,7 @@
 authors: ["kokkos-team"]
 title: "Team"
 date: "2024-01-19"
-tags: ["Team", "Sandia"]
+tags: ["Team"]
 ---
 
 The Kokkos Team is dedicated to empowering computational scientists and


### PR DESCRIPTION
Rational: there is currently no tag for any other organization, not even a CEA one for the CExA Tea-Time page, and that "Sandia" tag is exclusively used here to annotate the Team page.
It looks just out of place and yield a "Team" "Sandia" marking which is not the message we are trying to convey.
<img width="647" alt="Screenshot 2025-04-25 at 4 05 04 PM" src="https://github.com/user-attachments/assets/9277bd3b-be0e-487b-97be-eebcb96f98e4" />
