### PR TITLE
Add Mailing Lists page with instructions to subscribe to announcements

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -195,32 +195,39 @@ parent = "Community"
 weight = 3
 
 [[languages.en.menu.main]]
+identifier = "community-mailing-lists"
+name = "Mailing Lists"
+url = "/community/mailing-lists/"
+parent = "Community"
+weight = 4
+
+[[languages.en.menu.main]]
 identifier = "tea-time"
 name = "CExA Tea Time"
 url = "/community/tea-time/"
 parent = "Community"
-weight = 4
+weight = 5
 
 [[languages.en.menu.main]]
 identifier = "release-briefings"
 name = "Release Briefings"
 url = "/community/release-briefings/"
 parent = "Community"
-weight = 5
+weight = 6
 
 [[languages.en.menu.main]]
 identifier = "applications"
 name = "Applications"
 url = "/community/applications/"
 parent = "Community"
-weight = 6
+weight = 7
 
 [[languages.en.menu.main]]
 identifier = "team"
 name = "Team"
 url = "/community/team/"
 parent = "Community"
-weight = 7
+weight = 8
 
 [params]
 search = true

--- a/content/community/mailing-lists.md
+++ b/content/community/mailing-lists.md
@@ -1,0 +1,17 @@
+---
+authors: ["kokkos-team"]
+title: "Mailing Lists"
+date: "2025-05-01"
+tags: ["Slack", "Community"]
+---
+
+# kokkos-announcements@lists.hpsf.io
+
+Mailing list for releases and events.
+
+Stay up-to-date with the latest Kokkos news! This low-traffic mailing list
+provides timely announcements regarding upcoming releases (branching and
+tagging), as well as notifications for events like release briefings and user
+group meetings.
+
+[Subscribe](https://lists.hpsf.io/g/kokkos-announcements)


### PR DESCRIPTION
We created a kokkos-announcements@lists.hpsf.io mailing list that we would like to advertise at KUG.
This page has instructions on how to subscribe to it.