### PR TITLE
Make citing-kokkos a top level alias on kokkos.org

### DIFF
--- a/content/about/citing-kokkos.md
+++ b/content/about/citing-kokkos.md
@@ -1,0 +1,105 @@
+---
+authors: ["kokkos-team"]
+title: "Citing Kokkos"
+date: "2025-05-12"
+tags: [""]
+url: "citing-kokkos"
+---
+
+## Citing Kokkos
+
+Use the following references when citing Kokkos in your work.
+
+### Overall Ecosystem
+
+The Kokkos Ecosystem citation is in particular appropriate when using multiple Kokkos subprojects.
+
+```
+@article{KokkosEcosystem2021,
+  author={Trott, Christian and Berger-Vergiat, Luc and Poliakoff, David and Rajamanickam, Sivasankaran
+          and Lebrun-Grandie, Damien and Madsen, Jonathan and Al Awar, Nader and Gligoric, Milos
+          and Shipman, Galen and Womeldorff, Geoff},
+  journal={Computing in Science Engineering},
+  title={The Kokkos Ecosystem: Comprehensive Performance Portability for High Performance Computing},
+  year={2021},
+  volume={23},
+  number={5},
+  pages={10-18},
+  doi={10.1109/MCSE.2021.3098509}}
+```
+
+
+### Kokkos Core
+
+The most recent (and primary) citation is:
+
+```
+@article{KokkosCore2022,
+  author={Trott, Christian R. and Lebrun-Grandié, Damien and Arndt, Daniel and Ciesko, Jan
+          and Dang, Vinh and Ellingwood, Nathan and Gayatri, Rahulkumar and Harvey, Evan
+          and Hollman, Daisy S. and Ibanez, Dan and Liber, Nevin and Madsen, Jonathan
+          and Miles, Jeff and Poliakoff, David and Powell, Amy and Rajamanickam, Sivasankaran
+          and Simberg, Mikael and Sunderland, Dan and Turcksin, Bruno and Wilke, Jeremiah},
+  journal={IEEE Transactions on Parallel and Distributed Systems},
+  title={Kokkos 3: Programming Model Extensions for the Exascale Era},
+  year={2022},
+  volume={33},
+  number={4},
+  pages={805-817},
+  doi={10.1109/TPDS.2021.3097283}}
+```
+
+
+A description of the fundamental concepts can be found here:
+
+```
+@article{KokkosCore2014,
+  title = "Kokkos: Enabling manycore performance portability through polymorphic memory access patterns ",
+  journal = "Journal of Parallel and Distributed Computing ",
+  volume = "74",
+  number = "12",
+  pages = "3202 - 3216",
+  year = "2014",
+  note = "Domain-Specific Languages and High-Level Frameworks for High-Performance Computing ",
+  issn = "0743-7315",
+  doi = "https://doi.org/10.1016/j.jpdc.2014.07.003",
+  url = "http://www.sciencedirect.com/science/article/pii/S0743731514001257",
+  author = "H. Carter Edwards and Christian R. Trott and Daniel Sunderland"
+}
+```
+
+
+### Kokkos Kernels
+
+```
+@misc{KokkosKernels2021,
+  title={Kokkos Kernels: Performance Portable Sparse/Dense Linear Algebra and Graph Kernels},
+  author={Sivasankaran Rajamanickam and Seher Acer and Luc Berger-Vergiat and Vinh Dang
+          and Nathan Ellingwood and Evan Harvey and Brian Kelley and Christian R. Trott
+          and Jeremiah Wilke and Ichitaro Yamazaki},
+  year={2021},
+  eprint={2103.11991},
+  archivePrefix={arXiv},
+  primaryClass={cs.MS},
+  url={https://arxiv.org/abs/2103.11991},
+}
+```
+
+### Kokkos Tools
+
+```
+@InProceedings{10.1007/978-3-030-02465-9_53,
+author="Hammond, Simon D.
+and Trott, Christian R.
+and Ibanez, Daniel
+and Sunderland, Daniel",
+title="Profiling and Debugging Support for the Kokkos Programming Model",
+booktitle="High Performance Computing",
+year="2018",
+publisher="Springer International Publishing",
+address="Cham",
+pages="743--754",
+isbn="978-3-030-02465-9"
+}
+```
+

--- a/content/about/citing-kokkos.md
+++ b/content/about/citing-kokkos.md
@@ -6,11 +6,11 @@ tags: [""]
 url: "citing-kokkos"
 ---
 
-## Citing Kokkos
+# Citing Kokkos
 
 Use the following references when citing Kokkos in your work.
 
-### Overall Ecosystem
+## Overall Ecosystem
 
 The Kokkos Ecosystem citation is in particular appropriate when using multiple Kokkos subprojects.
 
@@ -29,7 +29,7 @@ The Kokkos Ecosystem citation is in particular appropriate when using multiple K
 ```
 
 
-### Kokkos Core
+## Kokkos Core
 
 The most recent (and primary) citation is:
 
@@ -69,7 +69,7 @@ A description of the fundamental concepts can be found here:
 ```
 
 
-### Kokkos Kernels
+## Kokkos Kernels
 
 ```
 @misc{KokkosKernels2021,
@@ -85,7 +85,7 @@ A description of the fundamental concepts can be found here:
 }
 ```
 
-### Kokkos Tools
+## Kokkos Tools
 
 ```
 @InProceedings{10.1007/978-3-030-02465-9_53,
@@ -102,4 +102,3 @@ pages="743--754",
 isbn="978-3-030-02465-9"
 }
 ```
-

--- a/content/about/publications.md
+++ b/content/about/publications.md
@@ -9,7 +9,7 @@ This is a list of publications describing the Kokkos Ecosystem.
 
 ## Citing Kokkos
 
-For a list of recommended citations please go to [Citing Kokkos](https://kokkos.org/citing-kokkos).
+To ensure proper attribution in your work, please refer to our [Citing Kokkos](https://kokkos.org/citing-kokkos) page for a list of recommended citations.
 
 ## Publication List
 

--- a/content/about/publications.md
+++ b/content/about/publications.md
@@ -5,102 +5,11 @@ date: "2023-01-01"
 tags: [""]
 ---
 
+This is a list of publications describing the Kokkos Ecosystem.
+
 ## Citing Kokkos
 
-Use the following references when citing Kokkos in your work.
-
-### Overall Ecosystem
-
-The Kokkos Ecosystem citation is in particular appropriate when using multiple Kokkos subprojects.
-
-```
-@article{KokkosEcosystem2021,
-  author={Trott, Christian and Berger-Vergiat, Luc and Poliakoff, David and Rajamanickam, Sivasankaran
-          and Lebrun-Grandie, Damien and Madsen, Jonathan and Al Awar, Nader and Gligoric, Milos
-          and Shipman, Galen and Womeldorff, Geoff},
-  journal={Computing in Science Engineering},
-  title={The Kokkos Ecosystem: Comprehensive Performance Portability for High Performance Computing},
-  year={2021},
-  volume={23},
-  number={5},
-  pages={10-18},
-  doi={10.1109/MCSE.2021.3098509}}
-```
-
-
-### Kokkos Core
-
-The most recent (and primary) citation is:
-
-```
-@article{KokkosCore2022,
-  author={Trott, Christian R. and Lebrun-Grandié, Damien and Arndt, Daniel and Ciesko, Jan
-          and Dang, Vinh and Ellingwood, Nathan and Gayatri, Rahulkumar and Harvey, Evan
-          and Hollman, Daisy S. and Ibanez, Dan and Liber, Nevin and Madsen, Jonathan
-          and Miles, Jeff and Poliakoff, David and Powell, Amy and Rajamanickam, Sivasankaran
-          and Simberg, Mikael and Sunderland, Dan and Turcksin, Bruno and Wilke, Jeremiah},
-  journal={IEEE Transactions on Parallel and Distributed Systems},
-  title={Kokkos 3: Programming Model Extensions for the Exascale Era},
-  year={2022},
-  volume={33},
-  number={4},
-  pages={805-817},
-  doi={10.1109/TPDS.2021.3097283}}
-```
-
-
-A description of the fundamental concepts can be found here:
-
-```
-@article{KokkosCore2014,
-  title = "Kokkos: Enabling manycore performance portability through polymorphic memory access patterns ",
-  journal = "Journal of Parallel and Distributed Computing ",
-  volume = "74",
-  number = "12",
-  pages = "3202 - 3216",
-  year = "2014",
-  note = "Domain-Specific Languages and High-Level Frameworks for High-Performance Computing ",
-  issn = "0743-7315",
-  doi = "https://doi.org/10.1016/j.jpdc.2014.07.003",
-  url = "http://www.sciencedirect.com/science/article/pii/S0743731514001257",
-  author = "H. Carter Edwards and Christian R. Trott and Daniel Sunderland"
-}
-```
-
-
-### Kokkos Kernels
-
-```
-@misc{KokkosKernels2021,
-  title={Kokkos Kernels: Performance Portable Sparse/Dense Linear Algebra and Graph Kernels},
-  author={Sivasankaran Rajamanickam and Seher Acer and Luc Berger-Vergiat and Vinh Dang
-          and Nathan Ellingwood and Evan Harvey and Brian Kelley and Christian R. Trott
-          and Jeremiah Wilke and Ichitaro Yamazaki},
-  year={2021},
-  eprint={2103.11991},
-  archivePrefix={arXiv},
-  primaryClass={cs.MS},
-  url={https://arxiv.org/abs/2103.11991},
-}
-```
-
-### Kokkos Tools
-
-```
-@InProceedings{10.1007/978-3-030-02465-9_53,
-author="Hammond, Simon D.
-and Trott, Christian R.
-and Ibanez, Daniel
-and Sunderland, Daniel",
-title="Profiling and Debugging Support for the Kokkos Programming Model",
-booktitle="High Performance Computing",
-year="2018",
-publisher="Springer International Publishing",
-address="Cham",
-pages="743--754",
-isbn="978-3-030-02465-9"
-}
-```
+For a list of recommended citations please go to [Citing Kokkos](https://kokkos.org/citing-kokkos).
 
 ## Publication List
 


### PR DESCRIPTION
Splits citation instructions from publication list. https://kokkos.org/citing-kokkos will now be available as a link.