### PR TITLE
Adding developer meetings page

### DIFF
--- a/content/dev_meetings/kokkos_kernels.md
+++ b/content/dev_meetings/kokkos_kernels.md
@@ -1,0 +1,23 @@
+---
+title: "Kokkos Kernels devs meeting"
+date: "2025-08-28"
+---
+
+Overview
+--------
+The Kokkos Kernels developers meeting is intended to give a time to the developers to meet and discuss the needs of the library.
+The discussion typically focuses on new features development, algorithms improvements, bug fixes, platforms support, interaction and support for vendors libraries and community events organization.
+Occasionally new reseach topics in linear algebra, linear solvers and adjacent topics are scheduled.
+
+Connect
+-------
+* **Slack channel:** [# kokkos-kernels](https://kokkosteam.slack.com/archives/CMZDYKZ96)
+  (Contact the leads to get invited)
+* **Mailing list:** (TBD)
+
+Meetings
+--------
+* Schedule: one meeting every two weeks on Thursdays at 10am Mountain Time.
+* [Meeting link (Zoom)](https://zoom-lfx.platform.linuxfoundation.org/meeting/97120554343?password=4811bf7d-9296-4d3d-903a-6cbcc5492524)
+* Agenda (TBD)
+* Minutes previous meetings (TBD)

--- a/content/developer-meetings.md
+++ b/content/developer-meetings.md
@@ -1,0 +1,9 @@
+---
+title: "Kokkos Developer Meetings"
+date: "2025-08-28"
+---
+
+The Kokkos project's developers hold regular meetings to discuss ongoing developments, new feature designs, bug fixes, etc...
+You can find more information about each of these meetings on their individual pages listed below.
+
+[Kokkos Kernels]( {{< ref "dev_meetings/kokkos_kernels" >}} )


### PR DESCRIPTION
The idea is to inform the community about our ongoing meetings. This should allow all of us to more easily find the basic information about our meetings as well as publish agenda and meeting notes publicly.