### PR TITLE
Fix tab reference to the developer meetings page

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -211,7 +211,7 @@ weight = 8
 [[languages.en.menu.main]]
 identifier = "dev-meetings"
 name = "Developer Meetings"
-url = "developer-meetings"
+url = "/developer-meetings/"
 parent = "Community"
 weight = 9
 


### PR DESCRIPTION
Page is not found on the current website.
I checked locally that it does the right thing with my patch.