### PR TITLE
2026 developers meeting agenda

### DIFF
--- a/content/community/events/2026-03-09-developers-meeting.md
+++ b/content/community/events/2026-03-09-developers-meeting.md
@@ -17,3 +17,75 @@ Location: Sandia NM, Albuquerque, New Mexico
 ## Who attends?
 
 This meeting is dedicated to the Kokkos developers team and will be available by invitation only.
+
+## Agenda
+
+### Monday
+
+Morning
+* Team arrival
+* Badge office at IPOC: 1611 Innovation Pkwy SE, Albuquerque, NM 87123
+* Bring all your documents! Passport, driver license, visa documents, etc... this can take up to 1hr if the badge office needs to contact other sercices for confirmation.
+
+Afternoon
+* Welcoming remarks
+* Overview of the agenda
+* Details of the locations we will be at for the meeting (we will change rooms a bit...)
+* Documentation Hackathon
+
+Evening
+* Social Event: Bowling
+
+### Tuesday
+
+Morning
+* MDRange Policy performance discussion, will include online participants as well
+* HPSF update, what have we accomplished, what do we want to work on for the upcoming year?
+
+Afternoon
+* Working with AI assistant for coding and PR reviews
+
+Evening
+* Social Event: Hiking
+
+### Wednesday
+
+Morning - Working groups discussion
+* New training and eductional material WG (with Paul Z. online)
+* Build and packaging working group report
+* CI working group report
+
+Afternoon
+* Group picture
+* Kokkos Core interoperability
+  * Part 1: Fortran / Python
+  * Part 2: How do we use MDSpan with Core, Kernels, etc...
+
+Evening
+* Social Event: Christian hosting the group for drinks/food
+
+### Thursday
+
+Morning 
+* Release retrospective
+* Package versioning in the Ecosystem
+
+Afternoon
+* Kokkos Kernels build system hackathon
+  * Give TPLs a rational look and feel
+  * Make sure appropriate target are exported
+  * Remove Cuda dependency in spack package
+
+Evening
+* Social Event: board game
+
+### Friday
+
+Morning
+* Performance Monitoring
+  * What exists in Core and Kernels
+  * What approach and tools do we need for this
+ 
+Afternoon
+* When will we do our next devs meeting
+* Closing remarks

--- a/content/community/events/2026-03-09-developers-meeting.md
+++ b/content/community/events/2026-03-09-developers-meeting.md
@@ -24,17 +24,13 @@ This meeting is dedicated to the Kokkos developers team and will be available by
 
 Morning
 * Team arrival
-* Badge office at IPOC: 1611 Innovation Pkwy SE, Albuquerque, NM 87123
-* Bring all your documents! Passport, driver license, visa documents, etc... this can take up to 1hr if the badge office needs to contact other sercices for confirmation.
 
 Afternoon
 * Welcoming remarks
 * Overview of the agenda
-* Details of the locations we will be at for the meeting (we will change rooms a bit...)
-* Documentation Hackathon
-
-Evening
-* Social Event: Bowling
+* Hackathons:
+  * Documentation
+  * Kokkos Tools
 
 ### Tuesday
 
@@ -43,10 +39,12 @@ Morning
 * HPSF update, what have we accomplished, what do we want to work on for the upcoming year?
 
 Afternoon
-* Working with AI assistant for coding and PR reviews
+* Kokkos Core interoperability
+  * Part 1: Fortran / Python
+  * Part 2: How do we use MDSpan with Core, Kernels, etc...
 
 Evening
-* Social Event: Hiking
+* Social Event: Bowling
 
 ### Wednesday
 
@@ -54,30 +52,38 @@ Morning - Working groups discussion
 * New training and eductional material WG (with Paul Z. online)
 * Build and packaging working group report
 * CI working group report
+* Interaction with HPSF working groups (Benchmark, CI, Binary, Outreach...)
 
 Afternoon
 * Group picture
-* Kokkos Core interoperability
-  * Part 1: Fortran / Python
-  * Part 2: How do we use MDSpan with Core, Kernels, etc...
+* NextSilicon update
+  * Core backend
+  * BLAS library
+  * How the co-design effort works with NS
 
 Evening
-* Social Event: Christian hosting the group for drinks/food
+* Social Event: Hiking
 
 ### Thursday
 
 Morning 
 * Release retrospective
 * Package versioning in the Ecosystem
+* Ecosystem scope discussion
+  * What current project are at what level?
+  * What new project might join? Cabana, ArborX
 
 Afternoon
 * Kokkos Kernels build system hackathon
   * Give TPLs a rational look and feel
   * Make sure appropriate target are exported
   * Remove Cuda dependency in spack package
+* MDSPan/View hands on exercise
+  * Implement a custom layout
+  * Implement custom accessor
 
 Evening
-* Social Event: board game
+* Social Event: Christian hosting the group for drinks/food
 
 ### Friday
 
@@ -85,7 +91,14 @@ Morning
 * Performance Monitoring
   * What exists in Core and Kernels
   * What approach and tools do we need for this
+  * Watchr2 demo with Chris and Christian G.
+* AI Policy discussion
+  * what is allowed to do for dev team
+  * what do we expect for reviews/PRs
  
 Afternoon
+* Working with AI assistant for coding and PR reviews
+  * Chris demo + tools at Sandia + experience with AI
+  * Hands on experience/hackathon with AI
 * When will we do our next devs meeting
 * Closing remarks


### PR DESCRIPTION
Draft of the activities for the 2026 developers meeting in Sandia NM. Will need additional feedback as well as check rooms and settle on times. Evening activities need to be confirmed.