### PR TITLE
Adding Kokkos Kernels slides for release briefing 5.1.0

### DIFF
--- a/content/community/release-briefings.md
+++ b/content/community/release-briefings.md
@@ -14,14 +14,14 @@ Join us to learn about the latest changes and ask questions.
 
 Upcoming
 --------
+(TBD)
 
 Past
 ----
 * 2026/04/14: [Kokkos 5.1 Release Briefing](
   https://www.olcf.ornl.gov/calendar/kokkos-5-1-release-briefing-apr-2026/)
-  (download slides [Kokkos]()
+  (download slides [Kokkos](https://github.com/kokkos/kokkos-tutorials/blob/3f2477da774f4d61554dbcdc4cc6f4982b58f6dc/Other/ReleaseBriefings/release-51.pdf))
   [Kokkos Kernels](https://raw.githubusercontent.com/kokkos/kokkos-tutorials/0fb039020f4c9140f3b97b63d8e26e4907e76356/Other/ReleaseBriefings/kk-release-51.pdf))
-  ([watch on YouTube](https://youtu.be/Pklhkn7AHMA?si=6I4VIp1I-U_PE4SK))
 * 2025/11/25: [Kokkos 5.0 Release Briefing](
   https://www.olcf.ornl.gov/calendar/kokkos-5-0-release-briefing-nov-2025/)
   ([download slides](https://raw.githubusercontent.com/kokkos/kokkos-tutorials/8598e035fa1d41c02decff3f004b231d1e90aa08/Other/ReleaseBriefings/release-50.pdf))

--- a/content/community/release-briefings.md
+++ b/content/community/release-briefings.md
@@ -14,11 +14,14 @@ Join us to learn about the latest changes and ask questions.
 
 Upcoming
 --------
-* 2026/04/14: [Kokkos 5.1 Release Briefing](
-  https://www.olcf.ornl.gov/calendar/kokkos-5-1-release-briefing-apr-2026/)
 
 Past
 ----
+* 2026/04/14: [Kokkos 5.1 Release Briefing](
+  https://www.olcf.ornl.gov/calendar/kokkos-5-1-release-briefing-apr-2026/)
+  (download slides [Kokkos]()
+  [Kokkos Kernels](https://raw.githubusercontent.com/kokkos/kokkos-tutorials/0fb039020f4c9140f3b97b63d8e26e4907e76356/Other/ReleaseBriefings/kk-release-51.pdf))
+  ([watch on YouTube](https://youtu.be/Pklhkn7AHMA?si=6I4VIp1I-U_PE4SK))
 * 2025/11/25: [Kokkos 5.0 Release Briefing](
   https://www.olcf.ornl.gov/calendar/kokkos-5-0-release-briefing-nov-2025/)
   ([download slides](https://raw.githubusercontent.com/kokkos/kokkos-tutorials/8598e035fa1d41c02decff3f004b231d1e90aa08/Other/ReleaseBriefings/release-50.pdf))


### PR DESCRIPTION
We can wait for the other slides and update this PR but adding the kernels ones for now so it is not forgotten later...